### PR TITLE
最最最基本得组件

### DIFF
--- a/set_up_linux.sh
+++ b/set_up_linux.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+app_list="curl wget git zsh vim screen zip unzip"
+
+grep debian /etc/os-release && sudo apt install $app_list -y
+
+grep centos /etc/os-release && sudo yum install $app_list -y
+


### PR DESCRIPTION
+ 按说curl wget git应该已经装了
  - 没有git，这个脚本也执行不了啊
+ zsh 就是为了少配置
+ vi和vim在系统中预置关系就没搞清楚过
+ zip 和 unzip是其他一些后面要装得工具比如sdkman