### PR TITLE
✨ feat(provision): 完成脚本幂等加固与中文规范收敛

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,19 @@
+# 格式:
+# <gitmoji> <type>(<scope>)<!>: <subject>
+#
+# 示例:
+# ✨ feat(user): 增加幂等的超级用户初始化流程
+# 🐛 fix(pam): 避免重复插入 pam_ssh_agent_auth 配置
+# 🔧 chore(policy): 更新提交规范说明
+#
+# 类型:
+# feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert
+#
+# 说明:
+# - subject 使用祈使句，简洁，不要句号结尾
+# - 破坏性变更使用 ! 并添加 BREAKING CHANGE:
+
+
+
+Refs:
+Closes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Provision 仓库规范
+
+## 范围与基线
+- 安全基线默认面向团队共享主机，个人便利行为必须显式开启。
+- 脚本目标是可重复执行、可审计、可回滚。
+
+## Shell 开发风格
+- 所有脚本使用 `#!/bin/bash` 与 `set -euo pipefail`（除非有明确兼容性例外）。
+- 输入参数必须先校验再执行系统修改。
+- 支持选项的脚本必须提供 `--help`。
+- 错误信息应可定位并可执行。
+
+## 幂等要求
+- 重复执行不得产生重复配置或重复 key。
+- 已存在资源优先补齐或跳过，避免盲目覆盖。
+
+## 系统文件安全
+- 修改系统文件前必须创建时间戳备份。
+- 插入配置优先使用受管区块（begin/end marker）。
+- 涉及 sudoers 的写入必须先做语法校验。
+
+## 语言输出
+- 所有用户提示统一使用中文输出。
+
+## 认证与密码策略
+- 公钥可公开，但内置默认公钥在共享主机场景有误授权风险。
+- 默认允许 `empty-expire`，但必须输出风险提示。
+- 必须保留更安全策略（如 `locked`）并通过显式参数启用。
+
+## 提交信息规范
+格式：
+`<gitmoji> <type>(<scope>)<!>: <subject>`
+
+约束：
+- `gitmoji` 必填并与 `type` 语义一致。
+- `type` 仅允许：`feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`。
+- `scope` 可选但建议填写（如 `user`/`pam`/`tmux`/`git`/`policy`）。
+- `subject` 使用祈使句，简洁，不以句号结束。
+- 破坏性变更使用 `!`，并在正文或 footer 写 `BREAKING CHANGE:`。
+
+推荐映射：
+- `✨ feat`
+- `🐛 fix`
+- `📝 docs`
+- `♻️ refactor`
+- `✅ test`
+- `🔧 chore`
+- `🚀 perf`
+- `🚨 ci`
+
+## Commit 模板
+- 仓库提供 `.gitmessage`。
+- 本地启用：`git config commit.template .gitmessage`。

--- a/create-super-user.sh
+++ b/create-super-user.sh
@@ -1,51 +1,196 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-username=${1:-"zhenhua.lei"}
-filename=${username/\./""}
-pblickey=${2:-"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHbWEZygV6f+MENAwwP24NwGGMOqKC0XkH6DjEE7PVSA zhenhua.lei@GUI"}
-base_dir=$([ -d "/mnt/disk/sub/home" ] && echo /mnt/disk/sub/home || echo /home)
+DEFAULT_USERNAME="zhenhua.lei"
+DEFAULT_PUBKEY="ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHbWEZygV6f+MENAwwP24NwGGMOqKC0XkH6DjEE7PVSA zhenhua.lei@GUI"
+PASSWORD_POLICY="empty-expire"
+BASE_DIR=$([ -d "/mnt/disk/sub/home" ] && echo "/mnt/disk/sub/home" || echo "/home")
 
-# Function to find first available UID starting from 61919
-find_available_uid() {
-    local uid=61919
-    while id -u $uid >/dev/null 2>&1; do
-        ((uid++))
-    done
-    echo $uid
+warn() {
+  local msg="$1"
+  echo "警告: $msg" >&2
 }
 
-# Create group and set UID/GID for all users
-gid=$(find_available_uid)
-getent group $gid >/dev/null || sudo groupadd -g $gid $username
-optn_uid="-u $gid -g $gid"
+err() {
+  local msg="$1"
+  echo "错误: $msg" >&2
+}
 
-echo optn_uid : $optn_uid
-echo $username $filename $pblickey
-sudo useradd $username ${optn_uid} -m -s /bin/bash -b ${base_dir}
-set +e
-sudo usermod -aG wheel $username || sudo usermod -aG sudo $username
-set -e
-echo "$username ALL=(ALL) ALL" | sudo tee /etc/sudoers.d/$filename
-echo "Defaults:$username timestamp_timeout=1000" | sudo tee -a /etc/sudoers.d/$filename
-echo "Defaults:$username env_keep += \"SSH_AUTH_SOCK\"" | sudo tee -a /etc/sudoers.d/$filename
+usage() {
+  cat <<'EOF'
+用法:
+  create-super-user.sh [username] [public_key] [--password-policy <empty-expire|locked>] [--help]
 
-user_home=${base_dir}/$username
-user_ssh_directory=$user_home/.ssh
-user_file_auth_key=$user_ssh_directory/authorized_keys
+示例:
+  ./create-super-user.sh zhenhua.lei "ssh-ed25519 AAAA... comment"
+  ./create-super-user.sh zhenhua.lei "ssh-ed25519 AAAA... comment" --password-policy locked
+EOF
+}
 
-sudo mkdir -p $user_ssh_directory
-sudo chown -hR $username:$username ${user_home}
-sudo touch $user_ssh_directory/authorized_keys
+is_valid_username() {
+  local value="$1"
+  [[ "$value" =~ ^[a-z_][a-z0-9_.-]{0,31}$ ]]
+}
 
-echo $pblickey | sudo tee $user_file_auth_key
+is_valid_pubkey() {
+  local value="$1"
+  [[ "$value" =~ ^(ssh-ed25519|ssh-rsa|ecdsa-sha2-nistp(256|384|521))\ [A-Za-z0-9+/=]+(\ .*)?$ ]]
+}
 
-sudo chown -hR $username:$username $user_file_auth_key
-sudo chmod 700 ${user_home}
-sudo chmod 700 $user_ssh_directory
-sudo chmod 600 $user_file_auth_key
+find_available_id() {
+  local id=61919
+  while getent passwd "$id" >/dev/null 2>&1 || getent group "$id" >/dev/null 2>&1; do
+    ((id++))
+  done
+  echo "$id"
+}
 
-sudo passwd -d $username
-sudo chage -d 0 $username
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || {
+    err "缺少必要命令: $1"
+    exit 1
+  }
+}
 
+USERNAME="$DEFAULT_USERNAME"
+PUBLIC_KEY="$DEFAULT_PUBKEY"
+POSITIONAL_INDEX=0
+
+while (($# > 0)); do
+  case "$1" in
+    --password-policy)
+      shift
+      if (($# == 0)); then
+        err "--password-policy 需要参数值。"
+        usage
+        exit 1
+      fi
+      PASSWORD_POLICY="$1"
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --*)
+      err "未知参数: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      if ((POSITIONAL_INDEX == 0)); then
+        USERNAME="$1"
+      elif ((POSITIONAL_INDEX == 1)); then
+        PUBLIC_KEY="$1"
+      else
+        err "位置参数过多。"
+        usage
+        exit 1
+      fi
+      ((POSITIONAL_INDEX += 1))
+      ;;
+  esac
+  shift
+done
+
+case "$PASSWORD_POLICY" in
+  empty-expire|locked) ;;
+  *)
+    err "无效的 --password-policy: $PASSWORD_POLICY"
+    exit 1
+    ;;
+esac
+
+if ! is_valid_username "$USERNAME"; then
+  err "用户名不合法: '$USERNAME'。"
+  exit 1
+fi
+
+if ! is_valid_pubkey "$PUBLIC_KEY"; then
+  err "SSH 公钥格式不合法。"
+  exit 1
+fi
+
+if [[ "$PUBLIC_KEY" == "$DEFAULT_PUBKEY" ]]; then
+  warn "正在使用内置默认公钥。共享主机建议显式传入公钥。"
+fi
+
+require_command sudo
+require_command useradd
+require_command usermod
+require_command getent
+require_command visudo
+
+SUDOERS_FILE_SAFE_NAME="$(echo "$USERNAME" | tr -cd '[:alnum:]_.-' | tr '.' '_')"
+SUDOERS_FILE="/etc/sudoers.d/${SUDOERS_FILE_SAFE_NAME}"
+SUDOERS_MARK_BEGIN="# --- create-super-user managed block (BEGIN) ---"
+SUDOERS_MARK_END="# --- create-super-user managed block (END) ---"
+
+if id "$USERNAME" >/dev/null 2>&1; then
+  echo "用户 '$USERNAME' 已存在，继续执行补齐逻辑。"
+  USER_HOME="$(getent passwd "$USERNAME" | cut -d: -f6)"
+  PRIMARY_GROUP="$(id -gn "$USERNAME")"
+else
+  if getent group "$USERNAME" >/dev/null 2>&1; then
+    GID="$(getent group "$USERNAME" | cut -d: -f3)"
+  else
+    GID="$(find_available_id)"
+    sudo groupadd -g "$GID" "$USERNAME"
+  fi
+
+  sudo useradd "$USERNAME" -u "${GID}" -g "${GID}" -m -s /bin/bash -b "$BASE_DIR"
+  USER_HOME="$(getent passwd "$USERNAME" | cut -d: -f6)"
+  PRIMARY_GROUP="$(id -gn "$USERNAME")"
+fi
+
+if getent group wheel >/dev/null 2>&1; then
+  sudo usermod -aG wheel "$USERNAME"
+elif getent group sudo >/dev/null 2>&1; then
+  sudo usermod -aG sudo "$USERNAME"
+else
+  warn "系统不存在 wheel 或 sudo 组，跳过管理员组分配。"
+fi
+
+SUDOERS_TMP="$(mktemp)"
+cat >"$SUDOERS_TMP" <<EOF
+${SUDOERS_MARK_BEGIN}
+$USERNAME ALL=(ALL) ALL
+Defaults:$USERNAME timestamp_timeout=1000
+Defaults:$USERNAME env_keep += "SSH_AUTH_SOCK"
+${SUDOERS_MARK_END}
+EOF
+
+sudo visudo -cf "$SUDOERS_TMP" >/dev/null
+sudo install -m 0440 "$SUDOERS_TMP" "$SUDOERS_FILE"
+rm -f "$SUDOERS_TMP"
+
+USER_SSH_DIR="${USER_HOME}/.ssh"
+USER_AUTH_KEYS="${USER_SSH_DIR}/authorized_keys"
+
+sudo install -d -m 0700 -o "$USERNAME" -g "$PRIMARY_GROUP" "$USER_SSH_DIR"
+sudo touch "$USER_AUTH_KEYS"
+sudo chown "$USERNAME:$PRIMARY_GROUP" "$USER_AUTH_KEYS"
+sudo chmod 0600 "$USER_AUTH_KEYS"
+
+if sudo grep -Fxq "$PUBLIC_KEY" "$USER_AUTH_KEYS"; then
+  echo "公钥已存在于 ${USER_AUTH_KEYS}，跳过追加。"
+else
+  echo "$PUBLIC_KEY" | sudo tee -a "$USER_AUTH_KEYS" >/dev/null
+  echo "已将公钥写入 ${USER_AUTH_KEYS}。"
+fi
+
+sudo chmod 0700 "$USER_HOME"
+
+case "$PASSWORD_POLICY" in
+  empty-expire)
+    warn "应用密码策略 empty-expire（风险较高，仅建议在受控环境使用）。"
+    sudo passwd -d "$USERNAME"
+    sudo chage -d 0 "$USERNAME"
+    ;;
+  locked)
+    echo "应用密码策略: locked。"
+    sudo passwd -l "$USERNAME"
+    ;;
+esac
+
+echo "用户 '$USERNAME' 初始化完成。"

--- a/git/source/config-user-6639hk.sh
+++ b/git/source/config-user-6639hk.sh
@@ -1,5 +1,35 @@
 #!/bin/bash
 
-git config user.email "leizhenhua@arrailgroup.com"
-git config user.name "zhenhua.lei"
+set -euo pipefail
 
+show_value() {
+  local level="$1"
+  local key="$2"
+  local value
+  value="$(git config "--${level}" "$key" 2>/dev/null || true)"
+  if [[ -n "$value" ]]; then
+    echo "  ${key}=${value}"
+  else
+    echo "  ${key}=<未设置>"
+  fi
+}
+
+echo "Local 配置列表:"
+local_list="$(git config --local --list 2>/dev/null || true)"
+if [[ -n "$local_list" ]]; then
+  echo "$local_list"
+else
+  echo "<local 未发现配置>"
+fi
+show_value "local" "user.name"
+show_value "local" "user.email"
+
+echo "Global 配置列表:"
+global_list="$(git config --global --list 2>/dev/null || true)"
+if [[ -n "$global_list" ]]; then
+  echo "$global_list"
+else
+  echo "<global 未发现配置>"
+fi
+show_value "global" "user.name"
+show_value "global" "user.email"

--- a/git/source/config-user-me.sh
+++ b/git/source/config-user-me.sh
@@ -1,5 +1,35 @@
 #!/bin/bash
 
-git config user.email "leizhnxp@gmail.com"
-git config user.name "zhenhua.lei"
+set -euo pipefail
 
+show_value() {
+  local level="$1"
+  local key="$2"
+  local value
+  value="$(git config "--${level}" "$key" 2>/dev/null || true)"
+  if [[ -n "$value" ]]; then
+    echo "  ${key}=${value}"
+  else
+    echo "  ${key}=<未设置>"
+  fi
+}
+
+echo "Local 配置列表:"
+local_list="$(git config --local --list 2>/dev/null || true)"
+if [[ -n "$local_list" ]]; then
+  echo "$local_list"
+else
+  echo "<local 未发现配置>"
+fi
+show_value "local" "user.name"
+show_value "local" "user.email"
+
+echo "Global 配置列表:"
+global_list="$(git config --global --list 2>/dev/null || true)"
+if [[ -n "$global_list" ]]; then
+  echo "$global_list"
+else
+  echo "<global 未发现配置>"
+fi
+show_value "global" "user.name"
+show_value "global" "user.email"

--- a/pam/pam_ssh_agent_auth/install-and-config-pam-sudo.sh
+++ b/pam/pam_ssh_agent_auth/install-and-config-pam-sudo.sh
@@ -1,58 +1,118 @@
 #!/bin/bash
 
-# 检查是否具有root权限
-if [ "$EUID" -ne 0 ]; then
-  echo "请使用root权限运行该脚本。"
-  exit 1
-fi
+set -euo pipefail
 
-# 检查包管理器类型
-if type apt > /dev/null 2>&1; then
-  OS_TYPE="debian"
-elif type dnf > /dev/null 2>&1; then
-  OS_TYPE="rhel"
-else
-  echo "不支持的操作系统类型。"
-  exit 1
-fi
-
-# 根据操作系统类型安装pam_ssh_agent_auth
-if [ "$OS_TYPE" = "rhel" ]; then
-  dnf install -y pam_ssh_agent_auth
-elif [ "$OS_TYPE" = "debian" ]; then
-  apt-get update
-  apt-get install -y libpam-ssh-agent-auth
-fi
-
-# 配置pam_ssh_agent_auth（幂等）
+RESTART_SSH="yes"
 PAM_SSH_CONFIG="/etc/pam.d/sudo"
 PAM_SSH_AGENT_AUTH_LINE="auth sufficient pam_ssh_agent_auth.so file=~/.ssh/authorized_keys"
 MARK_BEGIN="# --- pam_ssh_agent_auth (BEGIN) ---"
 MARK_END="# --- pam_ssh_agent_auth (END) ---"
 
-# 如果已经存在 pam_ssh_agent_auth 行，则不重复插入
-if grep -Eq '^\s*auth\s+.*pam_ssh_agent_auth\.so' "$PAM_SSH_CONFIG"; then
-  echo "已检测到 /etc/pam.d/sudo 中存在 pam_ssh_agent_auth 配置，跳过重复插入。"
+say() { echo "$1"; }
+
+err() {
+  echo "错误: $1" >&2
+}
+
+usage() {
+  cat <<'EOF'
+用法:
+  install-and-config-pam-sudo.sh [--no-restart-ssh] [--help]
+EOF
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --no-restart-ssh)
+      RESTART_SSH="no"
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      err "未知参数: $1"
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ "$EUID" -ne 0 ]]; then
+  err "请使用 root 权限运行此脚本。"
+  exit 1
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+  OS_TYPE="debian"
+elif command -v dnf >/dev/null 2>&1; then
+  OS_TYPE="rhel"
 else
-  tmpfile=$(mktemp)
+  err "不支持的系统（未检测到 apt-get 或 dnf）。"
+  exit 1
+fi
+
+if [[ ! -f "$PAM_SSH_CONFIG" ]]; then
+  err "缺少 PAM 配置文件: $PAM_SSH_CONFIG"
+  exit 1
+fi
+
+if [[ "$OS_TYPE" == "rhel" ]]; then
+  dnf install -y pam_ssh_agent_auth
+else
+  apt-get update
+  apt-get install -y libpam-ssh-agent-auth
+fi
+
+backup_file() {
+  local timestamp
+  timestamp="$(date +%Y%m%d%H%M%S)"
+  local backup_path="${PAM_SSH_CONFIG}.bak.${timestamp}"
+  cp -a "$PAM_SSH_CONFIG" "$backup_path"
+  say "已创建备份: $backup_path"
+}
+
+write_managed_block() {
+  local source_file="$1"
+  local tmp_output
+  tmp_output="$(mktemp)"
+  awk -v mark_begin="$MARK_BEGIN" -v mark_end="$MARK_END" '
+    BEGIN {skip=0}
+    $0 == mark_begin {skip=1; next}
+    $0 == mark_end {skip=0; next}
+    skip == 0 {print}
+  ' "$source_file" >"$tmp_output"
+
   {
     echo "$MARK_BEGIN"
     echo "$PAM_SSH_AGENT_AUTH_LINE"
     echo "$MARK_END"
     echo
-    cat "$PAM_SSH_CONFIG"
-  } > "$tmpfile" && cp "$tmpfile" "$PAM_SSH_CONFIG" && rm -f "$tmpfile"
-  echo "已在 /etc/pam.d/sudo 顶部插入 pam_ssh_agent_auth 配置。"
+    cat "$tmp_output"
+  } >"${tmp_output}.merged"
+
+  cp "${tmp_output}.merged" "$source_file"
+  rm -f "$tmp_output" "${tmp_output}.merged"
+}
+
+if grep -Eq '^\s*auth\s+.*pam_ssh_agent_auth\.so' "$PAM_SSH_CONFIG"; then
+  say "$PAM_SSH_CONFIG 中已存在 pam_ssh_agent_auth 配置，跳过插入。"
+else
+  backup_file
+  write_managed_block "$PAM_SSH_CONFIG"
+  say "已更新 $PAM_SSH_CONFIG 中的受管 PAM 区块。"
 fi
 
-echo "pam_ssh_agent_auth 安装和配置步骤完成。"
+say "pam_ssh_agent_auth 安装和配置完成。"
 
-# 重新启动SSH服务
-if [ "$OS_TYPE" = "rhel" ]; then
-  systemctl restart sshd
-elif [ "$OS_TYPE" = "debian" ]; then
-  systemctl restart ssh
+if [[ "$RESTART_SSH" == "yes" ]]; then
+  if [[ "$OS_TYPE" == "rhel" ]]; then
+    systemctl restart sshd
+  else
+    systemctl restart ssh
+  fi
+  say "SSH 服务已重启。"
+else
+  say "由于 --no-restart-ssh，已跳过 SSH 重启。"
 fi
-
-echo "SSH服务已重新启动。"
-

--- a/tmux/oh-my-tmux/install.sh
+++ b/tmux/oh-my-tmux/install.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # ref https://github.com/gpakosz/.tmux/blob/master/README.md
 
 cd
+
 git clone https://github.com/gpakosz/.tmux.git
 ln -s -f .tmux/.tmux.conf
 cp .tmux/.tmux.conf.local .

--- a/tmux/source/reset_SSH_AUTH_SOCK.sh
+++ b/tmux/source/reset_SSH_AUTH_SOCK.sh
@@ -2,4 +2,3 @@
 
 # should be source in current session
 eval `tmux show-environment -s SSH_AUTH_SOCK`
-


### PR DESCRIPTION
- 增强 create-super-user.sh: 增加参数校验、幂等补齐、sudoers 校验和密码策略开关。

- 强化 PAM 脚本: 保留 OS_TYPE 语义，加入备份、受管区块和 --no-restart-ssh 支持。

- 调整 git 身份脚本为只读检查: 同时输出 local/global 配置与 user.name/user.email。

- 回退 tmux 脚本到简化流程，仅保留必要安全设置。

- 新增并落地仓库规范: 纯中文 AGENTS.md 与 .gitmessage 模板。